### PR TITLE
Add formatting as unsupported

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 * Matrix → Signal
   * [ ] Message content
     * [ ] Text
-    * [ ] ‡Formatting
+    * [ ] Formatting
     * [ ] Mentions
     * [ ] Media
       * [ ] Images
@@ -28,6 +28,7 @@
 * Signal → Matrix
   * [ ] Message content
     * [ ] Text
+    * [ ] Formatting
     * [ ] Mentions
     * [ ] Media
       * [ ] Images


### PR DESCRIPTION
Signal now supports formatting as of [v6.22.0](https://github.com/signalapp/Signal-Desktop/releases/tag/v6.22.0)