### PR TITLE
Don't break inbound bridging on DMing own account

### DIFF
--- a/pkg/signalmeow/receiving.go
+++ b/pkg/signalmeow/receiving.go
@@ -489,12 +489,8 @@ func incomingRequestHandlerWithDevice(device *Device) web.RequestHandlerFunc {
 								destination = &g
 							}
 							if destination == nil {
-								err := fmt.Errorf("sync message sent destination is nil")
-								zlog.Err(err).Msg("")
-								return nil, err
-							}
-							_, err = incomingDataMessage(ctx, device, content.SyncMessage.Sent.Message, device.Data.AciUuid, *destination)
-							if err != nil {
+								zlog.Warn().Msg("sync message sent destination is nil")
+							} else if _, err = incomingDataMessage(ctx, device, content.SyncMessage.Sent.Message, device.Data.AciUuid, *destination); err != nil {
 								zlog.Err(err).Msg("incomingDataMessage error")
 								return nil, err
 							}


### PR DESCRIPTION
Without this, sending a message in the Note to Self portal / DM with your own Signal account breaks all subsequent inbound bridging.