### PR TITLE
Fix nil dereferences

### DIFF
--- a/pkg/signalmeow/receiving.go
+++ b/pkg/signalmeow/receiving.go
@@ -206,8 +206,12 @@ func incomingRequestHandlerWithDevice(device *Device) web.RequestHandlerFunc {
 					device.IdentityStore,
 					libsignalgo.NewCallbackContext(ctx),
 				)
-				if err != nil {
+				if err != nil || usmc == nil {
+					if err == nil {
+						err = fmt.Errorf("usmc is nil")
+					}
 					zlog.Err(err).Msg("SealedSenderDecryptToUSMC error")
+					return nil, err
 				}
 
 				messageType, err := usmc.GetMessageType()

--- a/portal.go
+++ b/portal.go
@@ -326,16 +326,19 @@ func (portal *Portal) handleMatrixMessage(sender *User, evt *event.Event) {
 	start = time.Now()
 
 	msg, err := portal.convertMatrixMessage(ctx, sender, evt)
-	timestamp := *msg.DataMessage.Timestamp
-	if timestamp == 0 {
-		timestamp = uint64(start.UnixMilli())
-	}
-	if err != nil {
+	if err != nil || msg == nil {
+		if err == nil {
+			err = fmt.Errorf("msg is nil")
+		}
 		portal.log.Error().Msgf("Error converting message %s: %v", evt.ID, err)
 		go ms.sendMessageMetrics(evt, err, "Error converting", true)
 		return
 	}
 
+	timestamp := *msg.DataMessage.Timestamp
+	if timestamp == 0 {
+		timestamp = uint64(start.UnixMilli())
+	}
 	timings.convert = time.Since(start)
 	start = time.Now()
 


### PR DESCRIPTION
This avoids a few cases of nil being dereferenced, by returning when an error is seen / an important value is nil instead of continuing on.  This does not fix the underlying causes of those errors, though.