### PR TITLE
Use filename title as body if caption is empty

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -1353,6 +1353,9 @@ func (portal *Portal) handleSignalAttachmentMessage(portalMessage portalSignalMe
 	} else {
 		portal.log.Debug().Msgf("Received file attachment: %s", msg.ContentType)
 		content.MsgType = event.MsgFile
+		if content.Body == "" {
+			content.Body = content.FileName
+		}
 	}
 	portal.addSignalQuote(content, msg.Quote)
 	portal.addMentionsToMatrixBody(content, msg.Mentions)


### PR DESCRIPTION
This is done only for files (and not images, videos, or audio) since `m.file` is the only msgtype that [the spec](https://spec.matrix.org/latest/client-server-api/#mfile) explicitly recommends doing this to:

> body | string | Required: A human-readable description of the file. This is recommended to be the filename of the original upload.
> -- | -- | --
