### PR TITLE
Scope reply events to current portal & quoted user

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -963,13 +963,8 @@ func (portal *Portal) storeReactionInDB(
 
 func (portal *Portal) addSignalQuote(content *event.MessageEventContent, quote *signalmeow.IncomingSignalMessageQuoteData) {
 	if quote != nil {
-		puppet := portal.bridge.DB.Puppet.GetBySignalID(quote.QuotedSender)
-		if puppet == nil {
-			portal.log.Warn().Msgf("Couldn't find puppet for quoted sender %s", quote.QuotedSender)
-			return
-		}
 		originalMessage := portal.bridge.DB.Message.GetBySignalID(
-			puppet.SignalID, quote.QuotedTimestamp, portal.ChatID, portal.Receiver,
+			quote.QuotedSender, quote.QuotedTimestamp, portal.ChatID, portal.Receiver,
 		)
 		if originalMessage == nil {
 			portal.log.Warn().Msgf("Couldn't find message with Signal ID %s/%d", quote.QuotedSender, quote.QuotedTimestamp)

--- a/portal.go
+++ b/portal.go
@@ -963,7 +963,14 @@ func (portal *Portal) storeReactionInDB(
 
 func (portal *Portal) addSignalQuote(content *event.MessageEventContent, quote *signalmeow.IncomingSignalMessageQuoteData) {
 	if quote != nil {
-		originalMessage := portal.bridge.DB.Message.FindBySenderAndTimestamp(quote.QuotedSender, quote.QuotedTimestamp)
+		puppet := portal.bridge.DB.Puppet.GetBySignalID(quote.QuotedSender)
+		if puppet == nil {
+			portal.log.Warn().Msgf("Couldn't find puppet for quoted sender %s", quote.QuotedSender)
+			return
+		}
+		originalMessage := portal.bridge.DB.Message.GetBySignalID(
+			puppet.SignalID, quote.QuotedTimestamp, portal.ChatID, portal.Receiver,
+		)
 		if originalMessage == nil {
 			portal.log.Warn().Msgf("Couldn't find message with Signal ID %s/%d", quote.QuotedSender, quote.QuotedTimestamp)
 			return


### PR DESCRIPTION
When bridging a Signal quote to a Matrix reply, consider events only from the portal in which the reply is being bridged when searching for the replied-to message.

Also refuse to bridge the quote if there is no puppet for the Signal user who sent the message that was quoted.

---

This fixes a breakage in replies for DMs between two Signal users who are both logged into the bridge.  When one user sends a reply message, the reply that gets bridged to the other user's Matrix room may reference an event from the sender's Matrix room (since the bridge gives each user their own DM room).