### PR TITLE
Ensure user is invited to portals on update

### DIFF
--- a/user.go
+++ b/user.go
@@ -719,6 +719,7 @@ func (user *User) incomingMessageHandler(incomingMessage signalmeow.IncomingSign
 			}
 
 			// ensure everyone is invited to the group
+			portal.ensureUserInvited(user)
 			_ = ensureGroupPuppetsAreJoinedToPortal(context.Background(), user, portal)
 		} else {
 			if portal.shouldSetDMRoomMetadata() {


### PR DESCRIPTION
because if a user ever leaves a portal, there is no obvious way for them to rejoin it.

This is also useful if a user never got invited to a portal for whatever reason when the portal was created (which AIUI is the only other time an invite gets sent).