### PR TITLE
Set contact table profile key type to bytea

### DIFF
--- a/pkg/signalmeow/upgrade.go
+++ b/pkg/signalmeow/upgrade.go
@@ -2,6 +2,8 @@ package signalmeow
 
 import (
 	"database/sql"
+
+	"go.mau.fi/util/dbutil"
 )
 
 type upgradeFunc func(*sql.Tx, *StoreContainer) error
@@ -192,7 +194,10 @@ func upgradeV3(tx *sql.Tx, _ *StoreContainer) error {
 	return nil
 }
 
-func upgradeV4(tx *sql.Tx, _ *StoreContainer) error {
+func upgradeV4(tx *sql.Tx, c *StoreContainer) error {
+	if c.dialect != dbutil.Postgres.String() {
+		return nil
+	}
 	_, err := tx.Exec(`
 		ALTER TABLE signalmeow_contacts
 		ALTER COLUMN profile_key TYPE bytea USING profile_key::bytea


### PR DESCRIPTION
Make it use the same data type as the profile keys table. This fixes UTF encoding errors when using a postgres store.

---

Note that I haven't tested the upgrade function, but instead ran the ALTER & UPDATE commands on a live postgres database.

After doing so, logs no longer print errors like the following:

```
ERR StoreContactDetailsAsContact: error storing contact error="pq: invalid byte sequence for encoding \"UTF8\": 0xab" component=signalmeow
ERR StoreContactDetailsAsContact error error="pq: invalid byte sequence for encoding \"UTF8\": 0xab" component=signalmeow
```

It also solved the irritating issue of puppet avatars being repeatedly set & unset, which flooded Matrix rooms with profile events.