### PR TITLE
Message type refactoring

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -885,7 +885,6 @@ func (portal *Portal) handleSignalMessages(portalMessage portalSignalMessage) {
 		handler = portal.handleSignalTypingMessage
 	case signalmeow.IncomingSignalMessageTypeReceipt:
 		msgTypeName = "receipt"
-		portal.log.Debug().Msg("Received receipt message")
 		handler = portal.handleSignalReceiptMessage
 	case signalmeow.IncomingSignalMessageTypeCall:
 		msgTypeName = "call"
@@ -900,6 +899,7 @@ func (portal *Portal) handleSignalMessages(portalMessage portalSignalMessage) {
 		portal.log.Warn().Msgf("Unknown message type: %v", msgType)
 		return
 	}
+	portal.log.Debug().Msgf("Received %s message", msgTypeName)
 	if err := handler(portalMessage, intent); err != nil {
 		portal.log.Error().Err(err).Msgf("Failed to handle %s message", msgTypeName)
 		return

--- a/portal.go
+++ b/portal.go
@@ -863,45 +863,45 @@ func (portal *Portal) handleSignalMessages(portalMessage portalSignalMessage) {
 	}
 
 	var err error
-	var msgType string
-	switch portalMessage.message.MessageType() {
+	var msgTypeName string
+	switch msgType := portalMessage.message.MessageType(); msgType {
 	case signalmeow.IncomingSignalMessageTypeText:
-		msgType = "text"
+		msgTypeName = "text"
 		err = portal.handleSignalTextMessage(portalMessage, intent)
 	case signalmeow.IncomingSignalMessageTypeAttachment:
-		msgType = "attachment"
+		msgTypeName = "attachment"
 		err = portal.handleSignalAttachmentMessage(portalMessage, intent)
 	case signalmeow.IncomingSignalMessageTypeReaction:
-		msgType = "reaction"
+		msgTypeName = "reaction"
 		err = portal.handleSignalReactionMessage(portalMessage, intent)
 	case signalmeow.IncomingSignalMessageTypeDelete:
-		msgType = "redaction"
+		msgTypeName = "redaction"
 		err = portal.handleSignalDeleteMessage(portalMessage, intent)
 	case signalmeow.IncomingSignalMessageTypeSticker:
-		msgType = "sticker"
+		msgTypeName = "sticker"
 		err = portal.handleSignalStickerMessage(portalMessage, intent)
 	case signalmeow.IncomingSignalMessageTypeTyping:
-		msgType = "typing"
+		msgTypeName = "typing"
 		err = portal.handleSignalTypingMessage(portalMessage, intent)
 	case signalmeow.IncomingSignalMessageTypeReceipt:
-		msgType = "receipt"
+		msgTypeName = "receipt"
 		portal.log.Debug().Msg("Received receipt message")
 		err = portal.handleSignalReceiptMessage(portalMessage, intent)
 	case signalmeow.IncomingSignalMessageTypeCall:
-		msgType = "call"
+		msgTypeName = "call"
 		err = portal.handleSignalCallMessage(portalMessage, intent)
 	case signalmeow.IncomingSignalMessageTypeContactCard:
-		msgType = "contact card"
+		msgTypeName = "contact card"
 		err = portal.handleSignalContactCardMessage(portalMessage, intent)
 	case signalmeow.IncomingSignalMessageTypeUnhandled:
-		msgType = "unhandled"
+		msgTypeName = "unhandled"
 		err = portal.handleSignalUnhandledMessage(portalMessage, intent)
 	default:
-		portal.log.Warn().Msgf("Unknown message type: %v", portalMessage.message.MessageType())
+		portal.log.Warn().Msgf("Unknown message type: %v", msgType)
 		return
 	}
 	if err != nil {
-		portal.log.Error().Err(err).Msgf("Failed to handle %s message", msgType)
+		portal.log.Error().Err(err).Msgf("Failed to handle %s message", msgTypeName)
 		return
 	}
 }

--- a/portal.go
+++ b/portal.go
@@ -863,69 +863,45 @@ func (portal *Portal) handleSignalMessages(portalMessage portalSignalMessage) {
 	}
 
 	var err error
-	if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeText {
+	var msgType string
+	switch portalMessage.message.MessageType() {
+	case signalmeow.IncomingSignalMessageTypeText:
+		msgType = "text"
 		err = portal.handleSignalTextMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle text message")
-			return
-		}
-	} else if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeAttachment {
+	case signalmeow.IncomingSignalMessageTypeAttachment:
+		msgType = "attachment"
 		err = portal.handleSignalAttachmentMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle attachment message")
-			return
-		}
-	} else if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeReaction {
-		err := portal.handleSignalReactionMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle reaction message")
-			return
-		}
-	} else if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeDelete {
-		err := portal.handleSignalDeleteMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle redaction message")
-			return
-		}
-	} else if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeSticker {
-		err := portal.handleSignalStickerMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle sticker message")
-			return
-		}
-	} else if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeTyping {
-		err := portal.handleSignalTypingMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle typing message")
-			return
-		}
-	} else if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeReceipt {
+	case signalmeow.IncomingSignalMessageTypeReaction:
+		msgType = "reaction"
+		err = portal.handleSignalReactionMessage(portalMessage, intent)
+	case signalmeow.IncomingSignalMessageTypeDelete:
+		msgType = "redaction"
+		err = portal.handleSignalDeleteMessage(portalMessage, intent)
+	case signalmeow.IncomingSignalMessageTypeSticker:
+		msgType = "sticker"
+		err = portal.handleSignalStickerMessage(portalMessage, intent)
+	case signalmeow.IncomingSignalMessageTypeTyping:
+		msgType = "typing"
+		err = portal.handleSignalTypingMessage(portalMessage, intent)
+	case signalmeow.IncomingSignalMessageTypeReceipt:
+		msgType = "receipt"
 		portal.log.Debug().Msg("Received receipt message")
-		err := portal.handleSignalReceiptMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle receipt message")
-			return
-		}
-	} else if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeCall {
-		err := portal.handleSignalCallMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle call message")
-			return
-		}
-	} else if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeContactCard {
-		err := portal.handleSignalContactCardMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle contact card message")
-			return
-		}
-	} else if portalMessage.message.MessageType() == signalmeow.IncomingSignalMessageTypeUnhandled {
-		err := portal.handleSignalUnhandledMessage(portalMessage, intent)
-		if err != nil {
-			portal.log.Error().Err(err).Msg("Failed to handle unhandled message")
-			return
-		}
-	} else {
+		err = portal.handleSignalReceiptMessage(portalMessage, intent)
+	case signalmeow.IncomingSignalMessageTypeCall:
+		msgType = "call"
+		err = portal.handleSignalCallMessage(portalMessage, intent)
+	case signalmeow.IncomingSignalMessageTypeContactCard:
+		msgType = "contact card"
+		err = portal.handleSignalContactCardMessage(portalMessage, intent)
+	case signalmeow.IncomingSignalMessageTypeUnhandled:
+		msgType = "unhandled"
+		err = portal.handleSignalUnhandledMessage(portalMessage, intent)
+	default:
 		portal.log.Warn().Msgf("Unknown message type: %v", portalMessage.message.MessageType())
+		return
+	}
+	if err != nil {
+		portal.log.Error().Err(err).Msgf("Failed to handle %s message", msgType)
 		return
 	}
 }

--- a/portal.go
+++ b/portal.go
@@ -862,45 +862,45 @@ func (portal *Portal) handleSignalMessages(portalMessage portalSignalMessage) {
 		return
 	}
 
-	var err error
 	var msgTypeName string
+	var handler func(portalSignalMessage, *appservice.IntentAPI) error
 	switch msgType := portalMessage.message.MessageType(); msgType {
 	case signalmeow.IncomingSignalMessageTypeText:
 		msgTypeName = "text"
-		err = portal.handleSignalTextMessage(portalMessage, intent)
+		handler = portal.handleSignalTextMessage
 	case signalmeow.IncomingSignalMessageTypeAttachment:
 		msgTypeName = "attachment"
-		err = portal.handleSignalAttachmentMessage(portalMessage, intent)
+		handler = portal.handleSignalAttachmentMessage
 	case signalmeow.IncomingSignalMessageTypeReaction:
 		msgTypeName = "reaction"
-		err = portal.handleSignalReactionMessage(portalMessage, intent)
+		handler = portal.handleSignalReactionMessage
 	case signalmeow.IncomingSignalMessageTypeDelete:
 		msgTypeName = "redaction"
-		err = portal.handleSignalDeleteMessage(portalMessage, intent)
+		handler = portal.handleSignalDeleteMessage
 	case signalmeow.IncomingSignalMessageTypeSticker:
 		msgTypeName = "sticker"
-		err = portal.handleSignalStickerMessage(portalMessage, intent)
+		handler = portal.handleSignalStickerMessage
 	case signalmeow.IncomingSignalMessageTypeTyping:
 		msgTypeName = "typing"
-		err = portal.handleSignalTypingMessage(portalMessage, intent)
+		handler = portal.handleSignalTypingMessage
 	case signalmeow.IncomingSignalMessageTypeReceipt:
 		msgTypeName = "receipt"
 		portal.log.Debug().Msg("Received receipt message")
-		err = portal.handleSignalReceiptMessage(portalMessage, intent)
+		handler = portal.handleSignalReceiptMessage
 	case signalmeow.IncomingSignalMessageTypeCall:
 		msgTypeName = "call"
-		err = portal.handleSignalCallMessage(portalMessage, intent)
+		handler = portal.handleSignalCallMessage
 	case signalmeow.IncomingSignalMessageTypeContactCard:
 		msgTypeName = "contact card"
-		err = portal.handleSignalContactCardMessage(portalMessage, intent)
+		handler = portal.handleSignalContactCardMessage
 	case signalmeow.IncomingSignalMessageTypeUnhandled:
 		msgTypeName = "unhandled"
-		err = portal.handleSignalUnhandledMessage(portalMessage, intent)
+		handler = portal.handleSignalUnhandledMessage
 	default:
 		portal.log.Warn().Msgf("Unknown message type: %v", msgType)
 		return
 	}
-	if err != nil {
+	if err := handler(portalMessage, intent); err != nil {
 		portal.log.Error().Err(err).Msgf("Failed to handle %s message", msgTypeName)
 		return
 	}


### PR DESCRIPTION
This is a minor refactoring to improve code reuse & readability of calls to `IncomingSignalMessage.MessageType()`.

The only intended functional change is for all types of inbound messages to get debug logged, not just receipts.